### PR TITLE
feat(api): return worker's result on sync_send api

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -156,11 +156,17 @@ function setupAPI(api) {
             return res.end('request body parse failure.');
           }
 
+          var workerIds = Object.keys(cluster.workers);
+          var workerResults = [];
+
           var cmd = message && message.cmd;
           if (!cmd) {
             sendMessage(message);
-            res.statusCode = 200;
-            return res.end('OK');
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            for (var i = 0; i < workerIds.length; i++) {
+              workerResults.push('OK');
+            }
+            return res.end(JSON.stringify(workerResults));
           }
 
           if (typeof _messageListeners[cmd] === 'function') {
@@ -168,18 +174,19 @@ function setupAPI(api) {
             return res.end('server too busy.');
           }
 
-          var workerIds = Object.keys(cluster.workers);
           addMessageListener(cmd, function(msg, worker) {
             workerIds = workerIds.filter(function(v) {
               return v !== '' + worker.id;
             });
 
+            workerResults.push(msg && msg.msg || '');
+
             if (workerIds.length <= 0) {
               clearTimeout(timer);
               removeMessageListener(cmd);
-              res.statusCode = 200;
-              res.end('OK');
-             }
+              res.writeHead(200, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify(workerResults));
+            }
           });
 
           sendMessage(message);

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -109,7 +109,9 @@ describe('cluster', function() {
 
           res.setEncoding('utf-8');
           res.on('data', function(chunk) {
-            expect('OK').to.eql(chunk);
+            var result = JSON.parse(chunk);
+            expect(result).to.be.an('array');
+            expect(result.length).to.eql(conf.worker);
           });
           res.on('end', function() {
             done();


### PR DESCRIPTION
workerの処理を待ってレスポンスを返すAPI(POST:/sync_send)において、各workerからの実行結果をjsonの配列で返すように修正しました。