### PR TITLE
fix(shutdown): IPC channel is already disconnected

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -276,19 +276,29 @@ function shutdown() {
   }
 
   // if all worker has been disconnected
-  cluster.disconnect(function(){
-    logger.debug('all workers has been disconnected');
-    if (_pidfile) {
-      try {
-        fs.unlinkSync(_pidfile);
-      } catch (e) {
+  cluster.disconnect(function() {
+    setTimeout(function() {
+      function _shutdown() {
+        logger.debug('all workers has been disconnected');
+        if (_pidfile) {
+          try {
+            fs.unlinkSync(_pidfile);
+          } catch (e) {
+          }
+        }
+        // in case worker processes are still alive
+        process.nextTick(function() {
+          logger.debug('process exit with code 0');
+          process.exit(0);
+        });
       }
-    }
-    // in case worker processes are still alive
-    process.nextTick(function(){
-      logger.debug('process exit with code 0');
-      process.exit(0);
-    });
+
+      if (!Object.keys(_disconnectTimer).length) {
+        return _shutdown();
+      }
+
+      setTimeout(_shutdown, _disconnectTimeout);
+    }, 100);
   });
 }
 


### PR DESCRIPTION
cluster.disconnectのcallbackはworkerがdisonnectされた時点で呼ばれるのではなく
workerにdisconnect命令を送った時点で呼ばれるので
workerが即時終了できなかったときにmasterが先に終了してしまいます。
その後workerがtimeoutなりで終了したときにmasterに通知しようとするけど
masterはすでにいないのでIPC channel...が出ます。

ということで、ちゃんとworkerの終了を待ってからmasterをshutdownするようにしました。
